### PR TITLE
feat(proxy46): limit number of connections per IPv4 client address

### DIFF
--- a/roles/proxy46/templates/nginx.conf.j2
+++ b/roles/proxy46/templates/nginx.conf.j2
@@ -1,13 +1,16 @@
 events {
-	worker_connections 1024;
+	worker_connections 2048;
 }
 
 error_log /dev/stdout {{ proxy46_log_level }};
 pid /var/empty/nginx.pid;
 
 stream {
+	limit_conn_zone $binary_remote_addr zone=stream_perclient:10m;
+
 	server {
 		listen 443;
+		limit_conn stream_perclient 300;
 		ssl_preread on;
 		resolver {{ proxy46_dns }} ipv4=off expect_a={{ famedly_server_host_ipv4 }};
 		proxy_bind [{{ proxy46_prefix }}$remote_addr]:$remote_port transparent;
@@ -23,11 +26,14 @@ http {
 	uwsgi_temp_path /var/empty 1 2;
 	scgi_temp_path /var/empty 1 2;
 
+	limit_conn_zone $binary_remote_addr zone=http_perclient:10m;
+
 	server {
 		listen 80;
 
 		location / {
 			resolver {{ proxy46_dns }} ipv4=off expect_a={{ famedly_server_host_ipv4 }};
+			limit_conn http_perclient 100;
 			proxy_bind [{{ proxy46_prefix }}$remote_addr]:$remote_port transparent;
 			proxy_pass http://$http_host:80;
 			proxy_http_version 1.1;


### PR DESCRIPTION
refs https://github.com/famedly/infra-meta/issues/2214

I also increased worker_connections from 1024 to 2048. Both values are still very low. My feeling would be to set it to 10000, but I wanted to confirm this before making this change. https://serverfault.com/questions/787919/optimal-value-for-nginx-worker-connections also says "Let's stick to 10k as a reasonable setting." and "You can do up to 10k without too much tuning." 

In the last days, the maximum (1024) was reached, but the CPU was below 5% continuously, and the RAM usage of nginx was also low, below 50 MiB (as seen in https://graph.famedly.de/d/efcde9b9-eed4-4472-a52b-96a4c45e13aa/overview?orgId=1&var-name=46-sni-proxy-nuremberg.famedly.de&var-maxmount=%2F&from=1747692438808&to=1747943050379). This also indicates that we can raise the limit, although suricata and this change may increase resource consumption a little bit.