### PR TITLE
fix(traefik): redeploy post-renewal.sh after cert renew [INFRA-308]

### DIFF
--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -6,6 +6,7 @@ traefik_base_path: /opt/traefik
 traefik_base_path_owner: "{{ traefik_user }}"
 traefik_base_path_group: "{{ traefik_user }}"
 traefik_base_path_mode: "0750"
+traefik_post_renewal_script: "{{ traefik_base_path }}/post-renewal.sh"
 
 traefik_dyn_config_path: "{{ traefik_base_path }}/config.d"
 

--- a/roles/traefik/tasks/manual-cert-management.yml
+++ b/roles/traefik/tasks/manual-cert-management.yml
@@ -24,3 +24,11 @@
       {{ traefik_container_volumes + [cert_mapping] }}
   vars:
     cert_mapping: "{{ traefik_cert_path }}:{{ traefik_cert_path }}:ro"
+
+- name: Template post-renewal script for cert reload
+  ansible.builtin.template:
+    src: post-renewal.sh.j2
+    dest: "{{ traefik_post_renewal_script }}"
+    owner: "{{ traefik_user_info.uid }}"
+    group: "{{ traefik_user_info.group }}"
+    mode: "0750"


### PR DESCRIPTION
## Summary
In `e30d704` the traefik role stopped deploying `post-renewal.sh` (to avoid a `lego_*` var). Template stayed; new hosts never get the file. `lego`/`lego-openbao` still call it via `ExecStartPost` and skip when missing → traefik keeps the old mTLS client cert until expiry → iris 502 / `vmagent_down`.

This PR redeploys the hook via traefik-owned `traefik_post_renewal_script` (same path inventory already uses).

https://famedly.atlassian.net/browse/INFRA-308

## Test plan
- [x] Deployed on `b9687aa2-…gedisa` — script present; timers will reload certs
- [ ] Merge + submodule bump, then roll `playbooks/traefik.yml` over GEDISA (`CRM_ALLOW_LIST` + slices)
- [ ] On already-stale hosts: `systemctl start lego*` or `docker restart traefik`