### PR TITLE
fix(traefik): correct ansible.builtin.copy FQCN typo

### DIFF
--- a/roles/traefik/tasks/deploy-manual-cert.yml
+++ b/roles/traefik/tasks/deploy-manual-cert.yml
@@ -9,7 +9,7 @@
     mode: "0664"
 
 - name: Deploy privkey to target host
-  ansible. builtin.copy:
+  ansible.builtin.copy:
     dest: "{{ privkey_path }}"
     content: "{{ item.privkey }}"
     owner: traefik


### PR DESCRIPTION
## Summary
- Fix typo `ansible. builtin.copy` → `ansible.builtin.copy` in `deploy-manual-cert.yml`, which broke `traefik_certs_to_deploy` (needed for Curamenta TLS from secret_storage / INFRA-320).

## Test plan
- [ ] Re-run Traefik play against a Curamenta host with `traefik_certs_to_deploy` set and confirm privkey/fullchain deploy without module resolution errors


Made with [Cursor](https://cursor.com)